### PR TITLE
V2 pours into V1 when V2 is nominally higher than V1

### DIFF
--- a/core-boards/hotswap/hotswap.brd
+++ b/core-boards/hotswap/hotswap.brd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.3.0">
+<eagle version="9.4.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="50" unitdist="mil" unit="mm" style="lines" multiple="1" display="no" altdistance="5" altunitdist="mil" altunit="mm"/>
+<grid distance="1" unitdist="mm" unit="mm" style="lines" multiple="1" display="no" altdistance="1" altunitdist="mm" altunit="mm"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="16" fill="1" visible="no" active="no"/>
@@ -4838,8 +4838,8 @@ design rules under a new name.</description>
 <attribute name="NAME" x="24.638" y="27.813" size="0.75" layer="25" rot="R90"/>
 <attribute name="SPICEPREFIX" value="R" x="154.94" y="71.12" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="Q2" library="IGVC-Discrete" package="DPACK_2" value="SUP75P03_07" x="31.75" y="43.18" smashed="yes" rot="R270">
-<attribute name="NAME" x="29.591" y="46.863" size="0.75" layer="25"/>
+<element name="Q2" library="IGVC-Discrete" package="DPACK_2" value="SUP75P03_07" x="29.21" y="44.45" smashed="yes" rot="R90">
+<attribute name="NAME" x="31.369" y="40.767" size="0.75" layer="25" rot="R180"/>
 </element>
 <element name="Q3" library="IGVC-Discrete" package="DPACK_2" value="SUP75P03_07" x="32.385" y="18.034" smashed="yes" rot="R270">
 <attribute name="NAME" x="34.798" y="21.717" size="0.75" layer="25"/>
@@ -4883,9 +4883,9 @@ design rules under a new name.</description>
 <attribute name="NAME" x="40.005" y="24.765" size="0.75" layer="25" rot="R180"/>
 <attribute name="SPICEPREFIX" value="C" x="38.1" y="26.67" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="C4" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C0805" package3d_urn="urn:adsk.eagle:package:23617/2" value=".1uF" x="29.21" y="35.56" smashed="yes" rot="R90">
-<attribute name="NAME" x="31.115" y="36.322" size="0.75" layer="25" rot="R90"/>
-<attribute name="SPICEPREFIX" value="C" x="29.21" y="35.56" size="1.778" layer="27" rot="R90" display="off"/>
+<element name="C4" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C0805" package3d_urn="urn:adsk.eagle:package:23617/2" value=".1uF" x="29.21" y="35.56" smashed="yes" rot="R270">
+<attribute name="NAME" x="27.305" y="34.798" size="0.75" layer="25" rot="R270"/>
+<attribute name="SPICEPREFIX" value="C" x="29.21" y="35.56" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
 <element name="E$1" library="RoboJackets-Aesthetics" package="ROBOBUZZ_0.8X" value="" x="44.45" y="2.54" smashed="yes"/>
 <element name="C3" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C0805" package3d_urn="urn:adsk.eagle:package:23617/2" value=".1uF" x="26.67" y="25.4" smashed="yes">
@@ -4912,38 +4912,35 @@ design rules under a new name.</description>
 <contactref element="R3" pad="1"/>
 <wire x1="27.94" y1="28.36" x2="27.09" y2="28.36" width="0.254" layer="1"/>
 <wire x1="27.09" y1="28.36" x2="26.67" y2="27.94" width="0.254" layer="1"/>
-<via x="26.67" y="27.94" extent="1-16" drill="0.35"/>
+<via x="26.67" y="27.94" extent="1-16" drill="0.4"/>
 <wire x1="33.02" y1="30.099" x2="32.639" y2="30.48" width="0.254" layer="1"/>
 <wire x1="32.639" y1="30.48" x2="30.8356" y2="30.48" width="0.254" layer="1"/>
-<via x="33.02" y="30.099" extent="1-16" drill="0.35"/>
+<via x="33.02" y="30.099" extent="1-16" drill="0.4"/>
 <contactref element="C4" pad="2"/>
 <contactref element="J2" pad="4"/>
 <contactref element="J1" pad="4"/>
 <wire x1="36.7" y1="26.67" x2="34.29" y2="26.67" width="0.254" layer="1"/>
-<via x="34.29" y="26.67" extent="1-16" drill="0.35"/>
+<via x="34.29" y="26.67" extent="1-16" drill="0.4"/>
 <wire x1="29.21" y1="26.0576" x2="28.2776" y2="26.0576" width="0.254" layer="1"/>
 <wire x1="27.62" y1="25.4" x2="28.2776" y2="26.0576" width="0.254" layer="1"/>
-<via x="29.21" y="26.0576" extent="1-16" drill="0.35"/>
+<via x="29.21" y="26.0576" extent="1-16" drill="0.4"/>
 <wire x1="25.4" y1="19.05" x2="22.99" y2="19.05" width="0.254" layer="1"/>
-<via x="25.4" y="19.05" extent="1-16" drill="0.35"/>
+<via x="25.4" y="19.05" extent="1-16" drill="0.4"/>
 <wire x1="22.99" y1="50.8" x2="25.4" y2="50.8" width="0.254" layer="1"/>
-<via x="25.4" y="50.8" extent="1-16" drill="0.35"/>
-<via x="27.686" y="36.957" extent="1-16" drill="0.35"/>
-<wire x1="29.21" y1="36.51" x2="28.763" y2="36.957" width="0.254" layer="1"/>
-<wire x1="28.763" y1="36.957" x2="27.686" y2="36.957" width="0.254" layer="1"/>
+<via x="25.4" y="50.8" extent="1-16" drill="0.4"/>
 <contactref element="C3" pad="2"/>
+<wire x1="29.21" y1="34.61" x2="29.21" y2="33.02" width="0.3" layer="1"/>
+<via x="29.21" y="33.02" extent="1-16" drill="0.4"/>
 </signal>
 <signal name="N$4">
 <contactref element="U1" pad="10"/>
 <contactref element="Q2" pad="G"/>
-<wire x1="26.95" y1="45.46" x2="30.48" y2="41.93" width="0.254" layer="1"/>
-<wire x1="30.48" y1="41.93" x2="30.48" y2="33.02" width="0.254" layer="1"/>
-<wire x1="32.019240625" y1="31.480759375" x2="35.2044" y2="31.480759375" width="0.254" layer="1"/>
-<wire x1="30.48" y1="33.02" x2="31.60014375" y2="31.89985625" width="0.254" layer="1"/>
-<wire x1="31.60014375" y1="31.89985625" x2="31.64983125" y2="31.89985625" width="0.254" layer="1"/>
-<wire x1="31.64983125" y1="31.89985625" x2="31.8135" y2="31.7361875" width="0.254" layer="1"/>
-<wire x1="31.8135" y1="31.7361875" x2="31.8135" y2="31.6865" width="0.254" layer="1"/>
-<wire x1="31.8135" y1="31.6865" x2="32.019240625" y2="31.480759375" width="0.254" layer="1"/>
+<wire x1="34.01" y1="42.17" x2="33.75" y2="41.91" width="0.3" layer="1"/>
+<wire x1="33.75" y1="41.91" x2="31.75" y2="41.91" width="0.3" layer="1"/>
+<wire x1="31.75" y1="41.91" x2="31" y2="41.16" width="0.3" layer="1"/>
+<wire x1="31" y1="33" x2="32.519240625" y2="31.480759375" width="0.3" layer="1"/>
+<wire x1="32.519240625" y1="31.480759375" x2="35.2044" y2="31.480759375" width="0.3" layer="1"/>
+<wire x1="31" y1="41.16" x2="31" y2="33" width="0.3" layer="1"/>
 </signal>
 <signal name="N$9">
 <contactref element="U1" pad="5"/>
@@ -4954,7 +4951,6 @@ design rules under a new name.</description>
 <wire x1="25.4" y1="27.94" x2="25.4" y2="28.36" width="0.254" layer="1"/>
 </signal>
 <signal name="VCC_WALL">
-<contactref element="Q2" pad="S"/>
 <contactref element="U1" pad="9"/>
 <contactref element="U1" pad="2"/>
 <contactref element="R2" pad="2"/>
@@ -4966,23 +4962,23 @@ design rules under a new name.</description>
 <vertex x="1.27" y="41.91"/>
 </polygon>
 <wire x1="26.67" y1="35.14" x2="26.88" y2="35.35" width="0.254" layer="1"/>
-<wire x1="26.88" y1="35.35" x2="26.95" y2="35.42" width="0.254" layer="1"/>
-<wire x1="26.95" y1="35.42" x2="26.95" y2="40.9" width="0.254" layer="1"/>
 <wire x1="35.2044" y1="30.98038125" x2="36.06038125" y2="30.98038125" width="0.254" layer="1"/>
 <wire x1="36.06038125" y1="30.98038125" x2="36.83" y2="31.75" width="0.254" layer="1"/>
-<via x="36.83" y="31.75" extent="1-16" drill="0.35"/>
+<via x="36.83" y="31.75" extent="1-16" drill="0.4"/>
 <wire x1="27.94" y1="32.639" x2="27.94" y2="34.29" width="0.254" layer="1"/>
 <wire x1="27.94" y1="34.29" x2="26.88" y2="35.35" width="0.254" layer="1"/>
 <wire x1="35.2044" y1="30.98038125" x2="30.8356" y2="30.98038125" width="0.254" layer="1"/>
 <wire x1="30.8356" y1="30.98038125" x2="29.59861875" y2="30.98038125" width="0.254" layer="1"/>
-<wire x1="29.59861875" y1="30.98038125" x2="29.0195" y2="31.5595" width="0.254" layer="1"/>
 <contactref element="J1" pad="1"/>
 <contactref element="C1" pad="1"/>
 <contactref element="C4" pad="1"/>
 <contactref element="J1" pad="2"/>
-<wire x1="29.0195" y1="31.5595" x2="27.94" y2="32.639" width="0.254" layer="1"/>
-<wire x1="29.0195" y1="31.5595" x2="29.21" y2="31.75" width="0.254" layer="1"/>
-<wire x1="29.21" y1="31.75" x2="29.21" y2="34.61" width="0.254" layer="1"/>
+<wire x1="29.59861875" y1="30.98038125" x2="27.94" y2="32.639" width="0.254" layer="1"/>
+<contactref element="Q2" pad="D"/>
+<wire x1="26.67" y1="35.14" x2="26.67" y2="39.37" width="1" layer="1"/>
+<wire x1="26.67" y1="39.37" x2="27.94" y2="39.37" width="1" layer="1"/>
+<wire x1="27.94" y1="39.37" x2="29.21" y2="38.1" width="1" layer="1"/>
+<wire x1="29.21" y1="38.1" x2="29.21" y2="36.51" width="1" layer="1"/>
 </signal>
 <signal name="N$1">
 <contactref element="Q1" pad="S"/>
@@ -4996,7 +4992,6 @@ design rules under a new name.</description>
 </signal>
 <signal name="VCC_COMP">
 <contactref element="U1" pad="8"/>
-<contactref element="Q2" pad="D"/>
 <polygon width="0.254" layer="1" thermals="no">
 <vertex x="58.42" y="55.88"/>
 <vertex x="58.42" y="2.54"/>
@@ -5007,6 +5002,7 @@ design rules under a new name.</description>
 <contactref element="J3" pad="2"/>
 <contactref element="C5" pad="1"/>
 <contactref element="Q3" pad="D"/>
+<contactref element="Q2" pad="S"/>
 </signal>
 <signal name="VCC_BATT">
 <polygon width="0.254" layer="1" thermals="no">

--- a/core-boards/hotswap/hotswap.sch
+++ b/core-boards/hotswap/hotswap.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.3.0">
+<eagle version="9.4.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -11511,9 +11511,9 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <attribute name="NAME" x="61.3536" y="47.2335" size="2.0862" layer="95" ratio="6" rot="SR0"/>
 <attribute name="VALUE" x="60.7431" y="44.69681875" size="2.08856875" layer="96" ratio="6" rot="SR0"/>
 </instance>
-<instance part="Q2" gate="G$1" x="114.3" y="73.66" smashed="yes" rot="R90">
-<attribute name="NAME" x="118.11" y="81.28" size="1.778" layer="95" rot="R180"/>
-<attribute name="VALUE" x="123.19" y="83.82" size="1.778" layer="96" rot="R180"/>
+<instance part="Q2" gate="G$1" x="114.3" y="73.66" smashed="yes" rot="MR90">
+<attribute name="NAME" x="110.49" y="81.28" size="1.778" layer="95" rot="MR180"/>
+<attribute name="VALUE" x="105.41" y="83.82" size="1.778" layer="96" rot="MR180"/>
 </instance>
 <instance part="Q1" gate="G$1" x="93.98" y="0" smashed="yes" rot="R270">
 <attribute name="NAME" x="92.71" y="-7.62" size="1.778" layer="95"/>
@@ -11683,9 +11683,9 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <net name="N$4" class="0">
 <segment>
 <pinref part="U1" gate="A" pin="G1"/>
+<wire x1="93.98" y1="38.1" x2="116.84" y2="38.1" width="0.1524" layer="91"/>
 <pinref part="Q2" gate="G$1" pin="G"/>
-<wire x1="93.98" y1="38.1" x2="111.76" y2="38.1" width="0.1524" layer="91"/>
-<wire x1="111.76" y1="38.1" x2="111.76" y2="71.12" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="71.12" x2="116.84" y2="38.1" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$9" class="0">
@@ -11699,15 +11699,12 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <net name="VCC_WALL" class="0">
 <segment>
 <pinref part="P+2" gate="VCC" pin="VCC"/>
-<pinref part="Q2" gate="G$1" pin="S"/>
-<wire x1="109.22" y1="76.2" x2="99.06" y2="76.2" width="0.1524" layer="91"/>
 <wire x1="20.32" y1="76.2" x2="35.56" y2="76.2" width="0.1524" layer="91"/>
 <wire x1="35.56" y1="76.2" x2="99.06" y2="76.2" width="0.1524" layer="91"/>
 <wire x1="99.06" y1="76.2" x2="99.06" y2="71.12" width="0.1524" layer="91"/>
 <pinref part="U1" gate="A" pin="V1"/>
 <wire x1="99.06" y1="71.12" x2="99.06" y2="35.56" width="0.1524" layer="91"/>
 <wire x1="99.06" y1="35.56" x2="93.98" y2="35.56" width="0.1524" layer="91"/>
-<junction x="99.06" y="76.2"/>
 <pinref part="U1" gate="A" pin="E1"/>
 <wire x1="38.1" y1="35.56" x2="35.56" y2="35.56" width="0.1524" layer="91"/>
 <wire x1="35.56" y1="35.56" x2="35.56" y2="76.2" width="0.1524" layer="91"/>
@@ -11733,6 +11730,9 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <pinref part="J1" gate="A" pin="2"/>
 <wire x1="7.62" y1="88.9" x2="15.24" y2="88.9" width="0.1524" layer="91"/>
 <wire x1="15.24" y1="88.9" x2="15.24" y2="86.36" width="0.1524" layer="91"/>
+<pinref part="Q2" gate="G$1" pin="D"/>
+<wire x1="109.22" y1="76.2" x2="99.06" y2="76.2" width="0.1524" layer="91"/>
+<junction x="99.06" y="76.2"/>
 </segment>
 </net>
 <net name="N$1" class="0">
@@ -11746,8 +11746,6 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <segment>
 <pinref part="U1" gate="A" pin="VS"/>
 <wire x1="93.98" y1="33.02" x2="119.38" y2="33.02" width="0.1524" layer="91"/>
-<wire x1="119.38" y1="33.02" x2="119.38" y2="76.2" width="0.1524" layer="91"/>
-<pinref part="Q2" gate="G$1" pin="D"/>
 <junction x="119.38" y="33.02"/>
 <wire x1="119.38" y1="33.02" x2="137.16" y2="33.02" width="0.1524" layer="91"/>
 <pinref part="P+3" gate="VCC" pin="VCC"/>
@@ -11767,6 +11765,8 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <pinref part="Q3" gate="G$1" pin="D"/>
 <wire x1="119.38" y1="33.02" x2="119.38" y2="-2.54" width="0.1524" layer="91"/>
 <junction x="119.38" y="-2.54"/>
+<pinref part="Q2" gate="G$1" pin="S"/>
+<wire x1="119.38" y1="76.2" x2="119.38" y2="33.02" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="VCC_BATT" class="0">


### PR DESCRIPTION
Q2 has direction flipped that the body diode of transistor allows V2 to consistently pours into V1 when V2 is nominally higher than V1. This pr flips direction of Q2 to so to accommodate the usage that the wall power would come from a PSU that gives 19V to the Hotswap while the secondary supply (battery) gives 24V.

Link to explanation of [Body Diode](https://www.digikey.com/en/articles/techzone/2016/sep/the-significance-of-the-intrinsic-body-diodes-inside-mosfets#targetText=These%20MOSFETs%20have%20diodes%20in,internal%20body%20to%20source%20connection.&targetText=Current%20typically%20flows%20from%20the,of%20the%20body%20diode%20polarity.)